### PR TITLE
create keycloak schema on start if it doesn't exists

### DIFF
--- a/charts/czertainly/Chart.lock
+++ b/charts/czertainly/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: keycloak-internal
   repository: file://../keycloak-internal
-  version: 1.0.0-4
+  version: 1.0.1-develop
 - name: common-credential-provider
   repository: file://../common-credential-provider
   version: 1.3.2-1
@@ -56,5 +56,5 @@ dependencies:
 - name: scheduler-service
   repository: file://../scheduler-service
   version: 1.0.0-1
-digest: sha256:fab503452c14da0ff824ca4b2037e4a7955a32fe85f365df6f11d86ae1d63391
-generated: "2024-02-18T12:28:24.49403+01:00"
+digest: sha256:a3cc39b7c59ef7b5e1843f6be93006b41c2f9707241b36ebe5e76b83d30fc3e7
+generated: "2024-02-20T12:01:32.419319+01:00"

--- a/charts/czertainly/Chart.yaml
+++ b/charts/czertainly/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: file://../keycloak-internal
     tags:
       - keycloak-internal
-    version: 1.0.0-5-develop
+    version: 1.0.1-develop
     alias: keycloakInternal
   - condition: commonCredentialProvider.enabled
     name: common-credential-provider

--- a/charts/czertainly/Chart.yaml
+++ b/charts/czertainly/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: file://../keycloak-internal
     tags:
       - keycloak-internal
-    version: 1.0.0-4
+    version: 1.0.0-5-develop
     alias: keycloakInternal
   - condition: commonCredentialProvider.enabled
     name: common-credential-provider

--- a/charts/keycloak-internal/Chart.yaml
+++ b/charts/keycloak-internal/Chart.yaml
@@ -29,4 +29,4 @@ sources:
   - https://github.com/3KeyCompany/CZERTAINLY
   - https://www.czertainly.com
   - https://docs.czertainly.com
-version: 1.0.0-4
+version: 1.0.0-5-develop

--- a/charts/keycloak-internal/Chart.yaml
+++ b/charts/keycloak-internal/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: trustLifecycleManagement
 apiVersion: v2
-appVersion: 1.0.0
+appVersion: 1.0.1
 name: keycloak-internal
 description: A Helm chart for internal Keycloak auth in CZERTAINLY platform.
 home: https://github.com/3KeyCompany/CZERTAINLY
@@ -29,4 +29,4 @@ sources:
   - https://github.com/3KeyCompany/CZERTAINLY
   - https://www.czertainly.com
   - https://docs.czertainly.com
-version: 1.0.0-5-develop
+version: 1.0.1-develop

--- a/charts/keycloak-internal/README.md
+++ b/charts/keycloak-internal/README.md
@@ -103,27 +103,27 @@ Global values are used to define common parameters for the chart and all its sub
 
 The following values may be configured:
 
-| Parameter                                    | Default value                               | Description                                                                            |
-|----------------------------------------------|---------------------------------------------|----------------------------------------------------------------------------------------|
-| image.registry                               | `docker.io`                                 | Docker registry name for the image                                                     |
-| image.repository                             | `3keycompany`                               | Docker image repository name                                                           |
-| image.name                                   | `czertainly-keycloak-optimized`             | Docker image name                                                                      |
-| image.tag                                    | `1.0.0`                                     | Docker image tag                                                                       |
-| image.digest                                 | `""`                                        | Docker image digest, will override tag if specified                                    |
-| image.pullPolicy                             | `IfNotPresent`                              | Image pull policy                                                                      |
-| image.pullSecrets                            | `[]`                                        | Array of secret names for image pull                                                   |
-| image.securityContext.runAsNonRoot           | `true`                                      | Run the container as non-root user                                                     |
-| image.securityContext.runAsUser              | `1000`                                      | User ID for the container                                                              |
-| image.securityContext.readOnlyRootFilesystem | `true`                                      | Run the container with read-only root filesystem                                       |
-| image.resources                              | `{}`                                        | The resources for the container                                                        |
-| podSecurityContext                           | `{}`                                        | Pod security context                                                                   |
-| volumes.ephemeral.type                       | `memory`                                    | Ephemeral volume type to be used                                                       |
-| volumes.ephemeral.sizeLimit                  | `"1Mi"`                                     | Ephemeral volume size limit                                                            |
-| volumes.ephemeral.storageClassName           | `""`                                        | Ephemeral volume storage class name for `storage` type                                 |
-| volumes.ephemeral.custom                     | `{}`                                        | Custom definition of the ephemeral volume for `custom` type                            |
-| logging.level                                | `"info"`                                    | Allowed values are `fatal`, `error`, `warn`, `info`, `debug`, `trace`, `all`, or `off` |
-| service.type                                 | `"ClusterIP"`                               | Type of the service that is exposed                                                    |
-| service.port                                 | `8080`                                      | Port number of the exposed service                                                     |
+| Parameter                                    | Default value                   | Description                                                                            |
+|----------------------------------------------|---------------------------------|----------------------------------------------------------------------------------------|
+| image.registry                               | `docker.io`                     | Docker registry name for the image                                                     |
+| image.repository                             | `3keycompany`                   | Docker image repository name                                                           |
+| image.name                                   | `czertainly-keycloak-optimized` | Docker image name                                                                      |
+| image.tag                                    | `1.0.1`                         | Docker image tag                                                                       |
+| image.digest                                 | `""`                            | Docker image digest, will override tag if specified                                    |
+| image.pullPolicy                             | `IfNotPresent`                  | Image pull policy                                                                      |
+| image.pullSecrets                            | `[]`                            | Array of secret names for image pull                                                   |
+| image.securityContext.runAsNonRoot           | `true`                          | Run the container as non-root user                                                     |
+| image.securityContext.runAsUser              | `1000`                          | User ID for the container                                                              |
+| image.securityContext.readOnlyRootFilesystem | `true`                          | Run the container with read-only root filesystem                                       |
+| image.resources                              | `{}`                            | The resources for the container                                                        |
+| podSecurityContext                           | `{}`                            | Pod security context                                                                   |
+| volumes.ephemeral.type                       | `memory`                        | Ephemeral volume type to be used                                                       |
+| volumes.ephemeral.sizeLimit                  | `"1Mi"`                         | Ephemeral volume size limit                                                            |
+| volumes.ephemeral.storageClassName           | `""`                            | Ephemeral volume storage class name for `storage` type                                 |
+| volumes.ephemeral.custom                     | `{}`                            | Custom definition of the ephemeral volume for `custom` type                            |
+| logging.level                                | `"info"`                        | Allowed values are `fatal`, `error`, `warn`, `info`, `debug`, `trace`, `all`, or `off` |
+| service.type                                 | `"ClusterIP"`                   | Type of the service that is exposed                                                    |
+| service.port                                 | `8080`                          | Port number of the exposed service                                                     |
 
 #### Customization parameters
 

--- a/charts/keycloak-internal/templates/keycloak-internal-deployment.yaml
+++ b/charts/keycloak-internal/templates/keycloak-internal-deployment.yaml
@@ -77,20 +77,47 @@ spec:
               value: {{ .Values.keycloak.proxyAddressForwarding | quote }}
             - name: KC_DB_SCHEMA
               value: {{ .Values.keycloak.dbSchema | quote }}
+            # KC_DB_* env variables are needed for Keycloak
             - name: KC_DB_URL
               value: {{ include "czertainly-lib.util.format.jdbcUrl" (list . "?characterEncoding=UTF-8") | quote }}
             - name: KC_DB_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: keycloak-internal-secret
-                  key: dbUsername
+                  key: database_user
             - name: KC_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: keycloak-internal-secret
-                  key: dbPassword
+                  key: database_password
             - name: KC_LOG_LEVEL
               value: {{ .Values.logging.level | quote }}
+            # PG* env variables are needed for psql command which is needed for postStart command
+            - name: PGHOST
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-internal-secret
+                  key: database_host
+            - name: PGPORT
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-internal-secret
+                  key: database_port
+            - name: PGDATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-internal-secret
+                  key: database_name
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-internal-secret
+                  key: database_user
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-internal-secret
+                  key: database_password
             {{- if $additionalEnv }}
               {{- $additionalEnv | nindent 12 }}
             {{- end }}
@@ -98,6 +125,13 @@ spec:
           envFrom:
             {{- $additionalEnvFrom | indent 12 }}
           {{- end }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "psql"
+                  - "-c"
+                  - "CREATE SCHEMA IF NOT EXISTS {{ .Values.keycloak.dbSchema }};"
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/keycloak-internal/templates/keycloak-internal-deployment.yaml
+++ b/charts/keycloak-internal/templates/keycloak-internal-deployment.yaml
@@ -131,7 +131,15 @@ spec:
                 command:
                   - "psql"
                   - "-c"
-                  - "CREATE SCHEMA IF NOT EXISTS {{ .Values.keycloak.dbSchema }};"
+                  - >
+                    DO $$
+                    BEGIN
+                      EXECUTE 'CREATE SCHEMA IF NOT EXISTS {{ .Values.keycloak.dbSchema }}';
+                      EXCEPTION
+                        WHEN duplicate_schema THEN RAISE NOTICE 'Schema "{{ .Values.keycloak.dbSchema }}" already exists';
+                        WHEN insufficient_privilege THEN RAISE NOTICE 'Permission denied to create schema "{{ .Values.keycloak.dbSchema }}"';
+                    END;
+                    $$
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/keycloak-internal/templates/keycloak-internal-secret.yaml
+++ b/charts/keycloak-internal/templates/keycloak-internal-secret.yaml
@@ -1,8 +1,11 @@
 apiVersion: v1
 data:
   # if the global values are defined, use it, otherwise use local values
-  dbPassword: {{ pluck "password" .Values.global.database .Values.database | compact | first | b64enc | quote }}
-  dbUsername: {{ pluck "username" .Values.global.database .Values.database | compact | first | b64enc | quote }}
+  database_host: {{ pluck "host" .Values.global.database .Values.database | compact | first | b64enc | quote }}
+  database_port: {{ pluck "port" .Values.global.database .Values.database | compact | first | toString | b64enc | quote }}
+  database_name: {{ pluck "name" .Values.global.database .Values.database | compact | first | b64enc | quote }}
+  database_user: {{ pluck "username" .Values.global.database .Values.database | compact | first | b64enc | quote }}
+  database_password: {{ pluck "password" .Values.global.database .Values.database | compact | first | b64enc | quote }}
   username: {{ required "Default Keycloak user is required: .Values.keycloak.admin.username!" .Values.keycloak.admin.username | b64enc | quote }}
   password: {{ required "Password for default Keycloak user is required: .Values.keycloak.admin.password!" .Values.keycloak.admin.password | b64enc | quote }}
 kind: Secret

--- a/charts/keycloak-internal/values.yaml
+++ b/charts/keycloak-internal/values.yaml
@@ -101,7 +101,7 @@ image:
   registry: docker.io
   repository: 3keycompany
   name: czertainly-keycloak-optimized
-  tag: 1.0.0
+  tag: 1.0.1
   # the digest to be used instead of the tag
   digest: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
CZERTAINLY-Core is creating all necessary schemas and tables automatically. Keycloak needs single schema and it needs to be present before Keycloak starts, if it is not available, Keycloak crashes.

I've analyzed two approaches to prepare schema if not available. The  first one is using  `initContainer`, it is implemented in my fork of CZERTAINLY-Helm-Charts in the [branch keycloak-schema](https://github.com/semik/CZERTAINLY-Helm-Charts/tree/keycloak-schema). The problem is that there is not small container image containing just `psql` command, at least one well maintained. For prove of concept I've used image `docker.io/3keycompany/czertainly-keycloak-optimized:develop-latest` which has `psql` present.  This approach works, but I think that creating complete container requires more resources that the second approach.

The second approach also depends on image `docker.io/3keycompany/czertainly-keycloak-optimized:develop-latest` but uses `lifecycle.postStart` hook. I think this consumes less resources than executing a complete container. Kubernetes doesn't guarantee that  `lifecycle.postStart` hook is executed before main process of container. In my experiments it number times managed to create schema before java starts Keycloak.

Environment variables PG* are needed for `psql` command line tool. I decided to rename variables in `dbUsername` and `dbPassword` to database_user/password in `keycloak-internal-secret` to be more consistent with `pyadcs-connector-secret.yaml`.

PL/pgSQL code is needed to assure that  `lifecycle.postStart` hook doesn't crash in case that database user doesn't have permissions to create schema. Database error is thrown even in situation schema exists, it looks like permissions are evaluated before conditional `IF NOT EXISTS`. 

Please note that I've been testing with image `docker.io/3keycompany/czertainly-keycloak-optimized:develop-latest`:
`helm upgrade --namespace czertainly -i --reset-values --values=.../czertainly-values.local.yaml --set keycloakInternal.image.tag=develop-latest --wait --timeout 30m czertainly-tlm czertainly-2.11.0.tgz`